### PR TITLE
Add example of a scoped resource

### DIFF
--- a/playground/settings.py
+++ b/playground/settings.py
@@ -21,6 +21,24 @@ DOMAIN = {
             },
         },
     },
+
+    # Example of a scoped resource
+    "projects": {
+        "url": "accounts/<regex('[a-f0-9]{24}'):owner>/projects",
+        "schema": {
+            "name": {
+                "type": "string",
+            },
+            "owner": {
+                "type": "objectid",
+                "data_relation": {
+                    "resource": "accounts",
+                    "field": "_id",
+                    "embeddable": True,
+                },
+            },
+        },
+    },
 }
 
 RESOURCE_METHODS = ["GET", "POST"]


### PR DESCRIPTION
Add the Project resource and set the `url` setting in the domain to allow it to sit as a sub resource under accounts. See: http://python-eve.org/features.html#sub-resources
